### PR TITLE
Separate storage buckets for each type

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ You can interact directly with the store if you want.
 
 ```ruby
 file = File.open("foo.txt")
-hash = Shrouded::Storage.store(file) # => "8843d7f92416211de9ebb963ff4ce28125932878"
-Shrouded::Storage.exists?(hash)      # => true
-Shrouded::Storage.get(hash).body     # => "foobar"
-Shrouded::Storage.delete(hash)       # => true
+hash = Shrouded::Storage.store("stuff", file) # => "8843d7f92416211de9ebb963ff4ce28125932878"
+Shrouded::Storage.exists?("stuff", hash)      # => true
+Shrouded::Storage.get("stuff", hash).body     # => "foobar"
+Shrouded::Storage.delete("stuff", hash)       # => true
 ```
 
 ## License

--- a/lib/shrouded/jobs/delete.rb
+++ b/lib/shrouded/jobs/delete.rb
@@ -3,8 +3,8 @@ module Shrouded
     class Delete < ActiveJob::Base
       queue_as :shrouded
 
-      def perform(hash)
-        Shrouded::Storage.delayed_delete(hash)
+      def perform(type, hash)
+        Shrouded::Storage.delayed_delete(type, hash)
       end
     end
   end

--- a/lib/shrouded/jobs/store.rb
+++ b/lib/shrouded/jobs/store.rb
@@ -3,8 +3,8 @@ module Shrouded
     class Store < ActiveJob::Base
       queue_as :shrouded
 
-      def perform(hash)
-        Shrouded::Storage.delayed_store(hash)
+      def perform(type, hash)
+        Shrouded::Storage.delayed_store(type, hash)
       end
     end
   end

--- a/lib/shrouded/layer.rb
+++ b/lib/shrouded/layer.rb
@@ -33,25 +33,25 @@ module Shrouded
       !readonly?
     end
 
-    def store(hash, file)
+    def store(type, hash, file)
       raise Shrouded::Errors::ReadOnlyError if readonly?
-      store!(hash, file)
+      store!(type, hash, file)
     end
 
-    def exists?(hash)
-      (directory(hash) &&
-      directory(hash).files.head(key_component(hash))) ? true : false
+    def exists?(type, hash)
+      (directory(type, hash) &&
+      directory(type, hash).files.head(key_component(type, hash))) ? true : false
     end
 
-    def get(hash)
-      if dir = directory(hash)
-        dir.files.get(key_component(hash))
+    def get(type, hash)
+      if dir = directory(type, hash)
+        dir.files.get(key_component(type, hash))
       end
     end
 
-    def delete(hash)
+    def delete(type, hash)
       raise Shrouded::Errors::ReadOnlyError if readonly?
-      delete!(hash)
+      delete!(type, hash)
     end
 
     private
@@ -60,36 +60,36 @@ module Shrouded
       { delayed: false, readonly: false, public: false, path: nil }
     end
 
-    def directory_component(hash)
-      [path, hash[0...2]].compact.join('/')
+    def directory_component(type, hash)
+      [path, type, hash[0...2]].compact.join('/')
     end
 
-    def key_component(hash)
+    def key_component(type, hash)
       hash[2..hash.length]
     end
 
-    def delete!(hash)
-      return false unless exists?(hash)
-      get(hash).destroy
+    def delete!(type, hash)
+      return false unless exists?(type, hash)
+      get(type, hash).destroy
     end
 
-    def directory(hash)
-      connection.directories.get(directory_component(hash))
+    def directory(type, hash)
+      connection.directories.get(directory_component(type, hash))
     end
 
-    def directory!(hash)
-      dir = directory(hash)
+    def directory!(type, hash)
+      dir = directory(type, hash)
       dir ||= connection.directories.create(
-        key:    directory_component(hash),
+        key:    directory_component(type, hash),
         public: public?
       )
       dir
     end
 
-    def store!(hash, file)
-      return get(hash) if exists?(hash)
-      directory!(hash).files.create(
-        key:    key_component(hash),
+    def store!(type, hash, file)
+      return get(type, hash) if exists?(type, hash)
+      directory!(type, hash).files.create(
+        key:    key_component(type, hash),
         body:   (file.kind_of?(Fog::Model) ? file.body : file),
         public: public?
       )

--- a/spec/shrouded/jobs/delete_spec.rb
+++ b/spec/shrouded/jobs/delete_spec.rb
@@ -3,13 +3,14 @@
 require 'spec_helper'
 
 describe Shrouded::Jobs::Delete do
+  let(:type) { 'test_files' }
   let(:hash) { '8843d7f92416211de9ebb963ff4ce28125932878' }
-  let(:job) { Shrouded::Jobs::Delete.new }
+  let(:job)  { Shrouded::Jobs::Delete.new }
 
   describe ".perform" do
     it "should perform the job" do
-      expect(Shrouded::Storage).to receive(:delayed_delete).with(hash)
-      job.perform(hash)
+      expect(Shrouded::Storage).to receive(:delayed_delete).with(type, hash)
+      job.perform(type, hash)
     end
   end
 end

--- a/spec/shrouded/jobs/store_spec.rb
+++ b/spec/shrouded/jobs/store_spec.rb
@@ -3,13 +3,14 @@
 require 'spec_helper'
 
 describe Shrouded::Jobs::Store do
+  let(:type) { 'test_files' }
   let(:hash) { '8843d7f92416211de9ebb963ff4ce28125932878' }
   let(:job) { Shrouded::Jobs::Store.new }
 
   describe ".perform" do
     it "should perform the job" do
-      expect(Shrouded::Storage).to receive(:delayed_store).with(hash)
-      job.perform(hash)
+      expect(Shrouded::Storage).to receive(:delayed_store).with(type, hash)
+      job.perform(type, hash)
     end
   end
 end

--- a/spec/shrouded/layer_spec.rb
+++ b/spec/shrouded/layer_spec.rb
@@ -3,8 +3,9 @@
 require 'spec_helper'
 
 describe Shrouded::Layer do
+  let(:type)        { 'test_files' }
   let(:root_path)   { Rails.root.join('tmp', 'spec') }
-  let(:target_path) { root_path.join('88', '43d7f92416211de9ebb963ff4ce28125932878') }
+  let(:target_path) { root_path.join(type, '88', '43d7f92416211de9ebb963ff4ce28125932878') }
   let(:hash)        { '8843d7f92416211de9ebb963ff4ce28125932878' }
   let(:file)        { File.open(File.expand_path("../../support/fixtures/file.txt", __FILE__)) }
   let(:connection)  { Fog::Storage.new({provider: 'Local', local_root: root_path}) }
@@ -83,10 +84,10 @@ describe Shrouded::Layer do
   end
 
   describe ".get" do
-    let(:result) { layer.get(hash) }
+    let(:result) { layer.get(type, hash) }
 
     context "when the file exists" do
-      before { layer.store(hash, file) }
+      before { layer.store(type, hash, file) }
 
       it "should retrieve the file" do
         expect(result).to be_a(Fog::Model)
@@ -101,7 +102,7 @@ describe Shrouded::Layer do
     end
 
     context "when the file doesn't exist, but the path does" do
-      before { FileUtils.mkdir_p(root_path.join('88')) }
+      before { FileUtils.mkdir_p(root_path.join(type, '88')) }
       it "should return nil" do
         expect(result).to be_nil
       end
@@ -109,10 +110,10 @@ describe Shrouded::Layer do
   end
 
   describe ".exists?" do
-    subject { layer.exists?(hash) }
+    subject { layer.exists?(type, hash) }
 
     context "when the file exists" do
-      before { layer.store(hash, file) }
+      before { layer.store(type, hash, file) }
       it { should be true }
     end
 
@@ -122,7 +123,7 @@ describe Shrouded::Layer do
   end
 
   describe ".store" do
-    let(:result) { layer.store(hash, file) }
+    let(:result) { layer.store(type, hash, file) }
 
     context "with a file" do
       before { result }
@@ -139,8 +140,8 @@ describe Shrouded::Layer do
 
     context "with a file and a path" do
       let(:layer)       { Shrouded::Layer.new(connection, path: 'mypath') }
-      let(:target_path) { root_path.join('mypath', '88', '43d7f92416211de9ebb963ff4ce28125932878') }
-      let!(:result) { layer.store(hash, file) }
+      let(:target_path) { root_path.join('mypath', type, '88', '43d7f92416211de9ebb963ff4ce28125932878') }
+      let!(:result) { layer.store(type, hash, file) }
 
       it "returns the file" do
         expect(result).to be_a(Fog::Model)
@@ -157,7 +158,7 @@ describe Shrouded::Layer do
     end
 
     context "when the file already exists" do
-      before { layer.store(hash, file) }
+      before { layer.store(type, hash, file) }
 
       it "returns the file" do
         expect(result).to be_a(Fog::Model)
@@ -173,11 +174,11 @@ describe Shrouded::Layer do
   end
 
   describe ".delete" do
-    let(:result) { layer.delete(hash) }
+    let(:result) { layer.delete(type, hash) }
 
     context "when the file exists" do
-      before { layer.store(hash, file) }
-      let!(:result) { layer.delete(hash) }
+      before { layer.store(type, hash, file) }
+      let!(:result) { layer.delete(type, hash) }
 
       it "returns true" do
         expect(result).to be true


### PR DESCRIPTION
Pros:
- Models can clean up after themselves when destroyed with a simple count by hash
- More descriptive path names

Cons:
- Less elegant API
- No deduplication across buckets (probably doesn't matter at all)
